### PR TITLE
Allow mixing references with regular text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0
+
+### Added
+
+- Extend referencing functionality to allow mixing the `{{` and `}}` syntax with
+  regular text. For example, in the configuration `before {{ filename }} after`,
+  the `{{ filename }}` part will be replaced in place and the `before` and
+  `after` strings will be maintained.
+
 ## 1.0.0
 
 ### Added

--- a/createNoteWithPrompting.js
+++ b/createNoteWithPrompting.js
@@ -195,8 +195,10 @@ async function elicitPromptAnswers(tp, config) {
 
         // For each object that had a reference.
         for (let i = 0; i < references.length; i++) {
-            // Set the config element value to the reference value.
-            config[references[i].key].value = config[references[i].reference].value
+            // Replace the config element reference placeholder with the reference value.
+            config[references[i].key].value = config[references[i].key].value.replace(
+                /{{.*}}/g, config[references[i].reference].value
+            )
 
             // If the value that referenced also requires prompting.
             if (config[references[i].key].prompt) {


### PR DESCRIPTION
Add functionality to mix referencing semantics with regular text, e.g., `before {{ filename }} after`.